### PR TITLE
chore(ci): switch from ghcr to dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ghcr.io/notnmeyer/mockpi:latest
+          tags: docker.io/notnmeyer/mockpi:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 mockpi is a tool for faking APIs. it responds to all methods and endpoints, optionally including a response body provided in the request as the `x-response-json` header.
 
 ```shell
-➜ curl -s -X POST -H 'x-response-json:{"id":0,"name":"nate"}' -d '{"name
-":"nate"}' localhost:8080/users/create| jq .
-{
-  "id": 0,
-  "name": "nate"
-}
+➜ curl -i -s -X POST -H 'x-response-json:{"id":0,"name":"nate"}' -d '{"name":"nate"}' localhost:8080/users/create
+HTTP/1.1 200 OK
+Date: Thu, 19 Oct 2023 04:14:33 GMT
+Content-Length: 22
+Content-Type: text/plain; charset=utf-8
+
+{"id":0,"name":"nate"}
 ```
 
 
@@ -20,10 +21,5 @@ mockpi is a tool for faking APIs. it responds to all methods and endpoints, opti
 
 ```shell
   docker buildx create --use
-
-  # local
-  docker buildx build --platform linux/amd64 -t ghcr.io/mockpi:latest . --load
-
-  # push
-  docker buildx build --platform linux/amd64 -t ghcr.io/mockpi:latest . --push
+  docker buildx build --platform linux/amd64 -t mockpi:latest . --load
 ```


### PR DESCRIPTION
ghcr images can be public but still require authentication, which is lame. publishing to dockerhub instead