### PR TITLE
chore: use go 1.21 locally

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
-{ pkgs ? import (fetchTarball "channel:nixos-23.05") {} }:
+{ pkgs ? import (fetchTarball "channel:nixos-unstable") {} }:
 
 pkgs.mkShell {
   packages = with pkgs; [
     delve
-    go
+    go_1_21
     gopls
     goreleaser
   ];


### PR DESCRIPTION
already building on 1.21 in ci