### PR TITLE
fix: handle missing x-response-json

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,13 +68,11 @@ func validateResponseBody(header map[string][]string) (string, error) {
 
 func validateResponseCode(header map[string][]string) (int, error) {
 	if val, exists := header["X-Response-Code"]; exists {
-		// verify its a number
 		code, err := strconv.Atoi(val[0])
 		if err != nil {
 			return http.StatusBadRequest, errorResponseFormatter("x-response-code must be a number")
 		}
 
-		// verify it falls in the range of status codes
 		if !(code >= 100 && code <= 599) {
 			return http.StatusBadRequest, errorResponseFormatter("x-response-code must be between 100 and 599")
 		}
@@ -82,7 +80,6 @@ func validateResponseCode(header map[string][]string) (int, error) {
 		return code, nil
 	}
 
-	// if x-response-code was not supplied default to a 200
 	return http.StatusOK, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -40,18 +40,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func buildResponse(header map[string][]string) (string, int) {
-	var (
-		responseBody string
-		responseCode int
-	)
-
 	responseBody, err := validateResponseBody(header)
 	if err != nil {
 		return err.Error(), http.StatusBadRequest
 
 	}
 
-	responseCode, err = validateResponseCode(header)
+	responseCode, err := validateResponseCode(header)
 	if err != nil {
 		return err.Error(), http.StatusBadRequest
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -41,6 +41,32 @@ func TestHandlerValidRequest(t *testing.T) {
 	}
 }
 
+func TestHandlerWithoutXResponseJson(t *testing.T) {
+	expectedResponseBody := `{"error":"x-response-json must be set on the request"}`
+	expectedResponseCode := http.StatusBadRequest
+
+	// set up the request
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make the request
+	rr := httptest.NewRecorder()
+	h := http.HandlerFunc(handler)
+	h.ServeHTTP(rr, req)
+
+	// status code
+	if status := rr.Code; status != expectedResponseCode {
+		t.Errorf("handler returned wrong status code: got '%d' want '%d'", status, expectedResponseCode)
+	}
+
+	// response body
+	if rr.Body.String() != expectedResponseBody {
+		t.Errorf("handler returned unexpected body: got '%s' want '%s'", rr.Body.String(), expectedResponseBody)
+	}
+}
+
 func TestHandlerWithInvalidXResponseJson(t *testing.T) {
 	invalidResponseBody := `{"foo":bar}`
 	expectedResponseBody := `{"error":"x-response-json must be valid JSON"}`


### PR DESCRIPTION
- now returns 400 when x-response-json is unset, rather than panicking 😅 
- refactored the header validation logic so its not order-dependent and overall just easier to follow