### PR TITLE
feat: respond to preflight requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":
 		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Access-Control-Max-Age", "86400")
@@ -43,7 +43,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	default:
 		responseBody, responseCode := buildResponse(r.Header)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.WriteHeader(responseCode)
 		w.Write([]byte(responseBody))
 	}

--- a/main.go
+++ b/main.go
@@ -32,11 +32,20 @@ func main() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	responseBody, responseCode := buildResponse(r.Header)
+	switch r.Method {
+	case "OPTIONS":
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "*")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		responseBody, responseCode := buildResponse(r.Header)
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(responseCode)
-	w.Write([]byte(responseBody))
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(responseCode)
+		w.Write([]byte(responseBody))
+	}
 }
 
 func buildResponse(header map[string][]string) (string, int) {

--- a/main.go
+++ b/main.go
@@ -35,14 +35,15 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "OPTIONS":
 		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 		w.Header().Set("Access-Control-Allow-Methods", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Access-Control-Max-Age", "86400")
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		responseBody, responseCode := buildResponse(r.Header)
-
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 		w.WriteHeader(responseCode)
 		w.Write([]byte(responseBody))
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -125,6 +125,26 @@ func TestHandlerWithInvalidXResponseCode(t *testing.T) {
 	}
 }
 
+func TestHandlerPreflightRequest(t *testing.T) {
+	expectedResponseCode := http.StatusNoContent
+
+	// set up the request
+	req, err := http.NewRequest("OPTIONS", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make the request
+	rr := httptest.NewRecorder()
+	h := http.HandlerFunc(handler)
+	h.ServeHTTP(rr, req)
+
+	// status code
+	if status := rr.Code; status != expectedResponseCode {
+		t.Errorf("handler returned wrong status code: got '%d' want '%d'", status, expectedResponseCode)
+	}
+}
+
 func TestValidateResponseCode(t *testing.T) {
 	valid := map[string][]string{
 		"X-Response-Code": {"201"},


### PR DESCRIPTION
respond to preflight OPTIONS requests,

```
➜ curl -i -X OPTIONS http://localhost:8080
HTTP/1.1 204 No Content
Access-Control-Allow-Headers: *
Access-Control-Allow-Methods: *
Access-Control-Allow-Origin: *
Access-Control-Max-Age: 86400
Connection: keep-alive
Date: Mon, 08 Jan 2024 17:54:14 GMT
```